### PR TITLE
I18n

### DIFF
--- a/src/i18n/Resolver.ts
+++ b/src/i18n/Resolver.ts
@@ -1,0 +1,29 @@
+export interface Resolver {
+    get(key: string, locale: string): string;
+}
+
+export class StringLocaleResolver implements Resolver {
+    private localeStringObj: any;
+
+    constructor(localeStringObj: any) {
+        this.localeStringObj = localeStringObj;
+    }
+
+    get(key: string, locale: string): string {
+        return this.localeStringObj[key][locale];
+    }
+}
+
+export const getLocale = () => {
+    let locale = window.localStorage.getItem("locale")
+
+    if (locale == undefined) {
+        locale = navigator.language;
+    }
+
+    return locale;
+}
+
+export const setLocale = (locale: string) => {
+    window.localStorage.setItem("locale", locale);
+}

--- a/src/i18n/Resolver.ts
+++ b/src/i18n/Resolver.ts
@@ -1,15 +1,20 @@
-export interface Resolver {
-    get(key: string, locale: string): string;
+export abstract class Resolver {
+    public getPrefix(): string {
+        return "$_";
+    }
+
+    public abstract get(key: string, locale: string): string;
 }
 
-export class StringLocaleResolver implements Resolver {
+export class StringLocaleResolver extends Resolver {
     private localeStringObj: any;
 
     constructor(localeStringObj: any) {
+        super();
         this.localeStringObj = localeStringObj;
     }
 
-    get(key: string, locale: string): string {
+    public get(key: string, locale: string): string {
         return this.localeStringObj[key][locale];
     }
 }

--- a/src/vdom/VApp.ts
+++ b/src/vdom/VApp.ts
@@ -5,6 +5,7 @@ import { Component, ComponentHolder } from './Component';
 import { EventHandler } from './EventHandler';
 import { invokeIfDefined } from './Common';
 import { Router } from '../Router';
+import { Resolver } from '../i18n/Resolver';
 
 export const unmanagedNode: string = "__UNMANAGED__"
 
@@ -34,6 +35,7 @@ export class VApp {
     router?: Router;
     pluginMap: Map<string, any> = new Map();
     oneTimeRenderCallbacks = new Array<AppEvent>();
+    i18nResolver: Resolver;
 
     /**
      * Constructs the app
@@ -320,5 +322,13 @@ export class VApp {
      */
     public get<T>(key: string) {
         return this.pluginMap.get(key) as T;
+    }
+
+    /**
+     * Configure the VApp to try and use a i18n Resolver
+     * @param resolver
+     */
+    public useTranslationResolver(resolver: Resolver) {
+        this.i18nResolver = resolver;
     }
 }

--- a/src/vdom/VApp.ts
+++ b/src/vdom/VApp.ts
@@ -5,6 +5,7 @@ import { Component, ComponentHolder } from './Component';
 import { EventHandler } from './EventHandler';
 import { invokeIfDefined } from './Common';
 import { Router } from '../Router';
+import { Resolver } from '../i18n/Resolver';
 
 export const unmanagedNode: string = "__UNMANAGED__"
 
@@ -34,6 +35,7 @@ export class VApp {
     router?: Router;
     pluginMap: Map<string, any> = new Map();
     oneTimeRenderCallbacks = new Array<AppEvent>();
+    i18nResolver: Resolver;
 
     /**
      * Constructs the app
@@ -321,5 +323,13 @@ export class VApp {
      */
     public get<T>(key: string) {
         return this.pluginMap.get(key) as T;
+    }
+
+    /**
+     * Configure the VApp to try and use a i18n Resolver
+     * @param resolver
+     */
+    public useTranslationResolver(resolver: Resolver) {
+        this.i18nResolver = resolver;
     }
 }

--- a/src/vdom/VApp.ts
+++ b/src/vdom/VApp.ts
@@ -35,7 +35,7 @@ export class VApp {
     router?: Router;
     pluginMap: Map<string, any> = new Map();
     oneTimeRenderCallbacks = new Array<AppEvent>();
-    i18nResolver: Resolver;
+    i18nResolver: Array<Resolver>;
 
     /**
      * Constructs the app
@@ -326,10 +326,14 @@ export class VApp {
     }
 
     /**
-     * Configure the VApp to try and use a i18n Resolver
+     * Configure the VApp to add an additional resolver for i18n strings
      * @param resolver
      */
     public useTranslationResolver(resolver: Resolver) {
-        this.i18nResolver = resolver;
+        if (this.i18nResolver == undefined) {
+            this.i18nResolver = new Array<Resolver>()
+        }
+
+        this.i18nResolver.push(resolver);
     }
 }

--- a/src/vdom/VNode.ts
+++ b/src/vdom/VNode.ts
@@ -136,7 +136,8 @@ export class VNode implements Comparable<VNode> {
     }
 
     public getInnerHtml(): string {
-        if (this.app.i18nResolver != undefined && this.app.i18nResolver.some(resolver => this.innerHtml.startsWith(resolver.getPrefix()))) {
+        if (this.app.i18nResolver != undefined
+            && this.app.i18nResolver.some(resolver => this.innerHtml.startsWith(resolver.getPrefix()))) {
             const resolver = this.app.i18nResolver.filter(resolver => this.innerHtml.startsWith(resolver.getPrefix()));
             let localized: string = undefined;
             for(const res of resolver) {

--- a/src/vdom/VNode.ts
+++ b/src/vdom/VNode.ts
@@ -4,6 +4,7 @@ import { v4 as uuid } from 'uuid';
 import { Props } from './Props';
 import { EvtHandlerFunc, EvtType } from './EventHandler';
 import { RouterLink } from '../Router';
+import { getLocale } from '../i18n/Resolver';
 
 export const kloudAppId = "data-kloudappid";
 
@@ -122,6 +123,13 @@ export class VNode implements Comparable<VNode> {
     }
 
     public getInnerHtml(): string {
+        if(this.app.i18nResolver != undefined) {
+            let localized = this.app.i18nResolver.get(this.innerHtml, getLocale());
+            if (localized != undefined && localized != this.innerHtml) {
+                return new Stringparser().parse(localized, this.props);
+            }
+        }
+
         return new Stringparser().parse(this.innerHtml, this.props);
     }
 

--- a/src/vdom/VNode.ts
+++ b/src/vdom/VNode.ts
@@ -136,9 +136,17 @@ export class VNode implements Comparable<VNode> {
     }
 
     public getInnerHtml(): string {
-        if(this.app.i18nResolver != undefined) {
-            let localized = this.app.i18nResolver.get(this.innerHtml, getLocale());
-            if (localized != undefined && localized != this.innerHtml) {
+        if (this.app.i18nResolver != undefined && this.app.i18nResolver.some(resolver => this.innerHtml.startsWith(resolver.getPrefix()))) {
+            const resolver = this.app.i18nResolver.filter(resolver => this.innerHtml.startsWith(resolver.getPrefix()));
+            let localized: string = undefined;
+            for(const res of resolver) {
+                localized = res.get(this.innerHtml, getLocale())
+                if(localized != undefined) {
+                    break;
+                }
+            }
+
+            if (localized != undefined) {
                 return new Stringparser().parse(localized, this.props);
             }
         }

--- a/src/vdom/VNode.ts
+++ b/src/vdom/VNode.ts
@@ -3,6 +3,7 @@ import { VApp, AppEvent } from './VApp'
 import { Props } from './Props';
 import { EvtHandlerFunc, EvtType } from './EventHandler';
 import { RouterLink } from '../Router';
+import { getLocale } from '../i18n/Resolver';
 
 export const kloudAppId = "data-kloudappid";
 
@@ -135,6 +136,13 @@ export class VNode implements Comparable<VNode> {
     }
 
     public getInnerHtml(): string {
+        if(this.app.i18nResolver != undefined) {
+            let localized = this.app.i18nResolver.get(this.innerHtml, getLocale());
+            if (localized != undefined && localized != this.innerHtml) {
+                return new Stringparser().parse(localized, this.props);
+            }
+        }
+
         return new Stringparser().parse(this.innerHtml, this.props);
     }
 


### PR DESCRIPTION
This PR adds the first implementation of i18n:

- You are able to register resolver in the VApp.
- If any resolver is present, it will greedily try to evaluate all resolvers, this is done using the overridable method: getPrefix() of the abstract Resolver. If multiple resolvers support the same prefix, it will use the first to return a non-undefined value.
- if no locale has been set using the "setLocale()" function, we will use the browsers navigator to determine a default
- If no suitable locale for a key or the key itself cannot be found in the resolvers, the un-resolved value will be displayed