### PR TITLE
Make i18n async #2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@kloudsoftware/eisen",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/Router.ts
+++ b/src/Router.ts
@@ -27,6 +27,10 @@ export class Router {
         this.componentMap.set(path, [component, props]);
     }
 
+    hasRouteRegistered(path: string) {
+        return this.componentMap.has(path);
+    }
+
     resolveRoute(path: string): boolean {
         history.replaceState(null, "", path)
 

--- a/src/i18n/Resolver.ts
+++ b/src/i18n/Resolver.ts
@@ -3,7 +3,7 @@ export abstract class Resolver {
         return "$_";
     }
 
-    public abstract get(key: string, locale: string): string;
+    public abstract get(key: string, locale: string): Promise<string>;
 }
 
 export class StringLocaleResolver extends Resolver {
@@ -14,8 +14,10 @@ export class StringLocaleResolver extends Resolver {
         this.localeStringObj = localeStringObj;
     }
 
-    public get(key: string, locale: string): string {
-        return this.localeStringObj[key][locale];
+    public get(key: string, locale: string): Promise<string> {
+        return new Promise((resolve, _) => {
+            resolve(this.localeStringObj[key][locale]);
+        });
     }
 }
 

--- a/src/i18n/Resolver.ts
+++ b/src/i18n/Resolver.ts
@@ -3,6 +3,10 @@ export abstract class Resolver {
         return "$_";
     }
 
+    public isStrict(): boolean {
+        return false;
+    }
+
     public abstract get(key: string, locale: string): Promise<string>;
 }
 

--- a/src/i18n/Resolver.ts
+++ b/src/i18n/Resolver.ts
@@ -19,8 +19,17 @@ export class StringLocaleResolver extends Resolver {
     }
 
     public get(key: string, locale: string): Promise<string> {
-        return new Promise((resolve, _) => {
-            resolve(this.localeStringObj[key][locale]);
+        return new Promise((resolve, reject) => {
+            const locales = this.localeStringObj[key];
+            if (locales == undefined) {
+                reject(`Could not find a match for ${key} for locale ${locale}`)
+            }
+            const result = locales[locale];
+            if (result != undefined) {
+                resolve(result);
+            } else {
+                reject(`Could not find a match for ${key} for locale ${locale}`)
+            }
         });
     }
 }

--- a/src/vdom/Common.ts
+++ b/src/vdom/Common.ts
@@ -124,15 +124,6 @@ const parse = (node: Element, app: VApp): VNode => {
 }
 
 /**
- * Takes a promise and returns one, wich always resovles, regardless of the outcome of the given promise
- * @param promise
- */
-export function reflect<T>(promise: Promise<T>): Promise<T> {
-    return promise.then((v: T) => { return v },
-        (e) => { return undefined });
-}
-
-/**
  * Inverts Promise.all
  * Resolves on first successful Promise
  * If all Promises fail, it will reject with the last error

--- a/src/vdom/Common.ts
+++ b/src/vdom/Common.ts
@@ -124,10 +124,29 @@ const parse = (node: Element, app: VApp): VNode => {
 }
 
 /**
- * Takes a promise wich always resovles, regardless of the outcome of the given promise
+ * Takes a promise and returns one, wich always resovles, regardless of the outcome of the given promise
  * @param promise
  */
-export function reflect<T>(promise: Promise<T>): Promise<T>{
-    return promise.then((v: T) => { return v},
-                        (e) => { return undefined});
+export function reflect<T>(promise: Promise<T>): Promise<T> {
+    return promise.then((v: T) => { return v },
+        (e) => { return undefined });
+}
+
+/**
+ * Inverts Promise.all
+ * Resolves on first successful Promise
+ * If all Promises fail, it will reject with the last error
+ * @param promises The promises to run
+ */
+export function raceToSuccess<T>(promises: Array<Promise<T>>): Promise<T> {
+    return Promise.all(promises.map(p => {
+        return p.then(
+            (val: T) => Promise.reject(val),
+            err => Promise.resolve(err)
+        );
+    }))
+        .then(
+            errors => Promise.reject(errors),
+            (val: T) => Promise.resolve(val)
+        );
 }

--- a/src/vdom/Common.ts
+++ b/src/vdom/Common.ts
@@ -122,3 +122,12 @@ const parse = (node: Element, app: VApp): VNode => {
 
     return vNode;
 }
+
+/**
+ * Takes a promise wich always resovles, regardless of the outcome of the given promise
+ * @param promise
+ */
+export function reflect<T>(promise: Promise<T>): Promise<T>{
+    return promise.then((v: T) => { return v},
+                        (e) => { return undefined});
+}

--- a/src/vdom/VApp.ts
+++ b/src/vdom/VApp.ts
@@ -102,7 +102,6 @@ export class VApp {
      * @param props
      */
     public routerMountComponent(component: Component, mount: VNode, props: Props): ComponentHolder {
-        console.log("component: ",component);
         if (this.router == undefined) {
             console.error("No router mounted")
             return undefined;

--- a/src/vdom/VNode.ts
+++ b/src/vdom/VNode.ts
@@ -1,4 +1,4 @@
-import { Comparable, arraysEquals, Stringparser, dataRegex, reflect, raceToSuccess } from './Common';
+import { Comparable, arraysEquals, Stringparser, dataRegex, raceToSuccess } from './Common';
 import { VApp, AppEvent } from './VApp'
 import { Props } from './Props';
 import { EvtHandlerFunc, EvtType } from './EventHandler';
@@ -173,28 +173,26 @@ export class VNode implements Comparable<VNode> {
                     return res.get(htmlToUse, locale.split("-")[0]);
                 });
 
+
+            const processMatch = (match: string) => {
+                if (match != undefined) {
+                    if (this.rawInnerHtml == undefined) {
+                        this.rawInnerHtml = htmlToUse;
+                    }
+                    this.lastResolvedLocale = locale;
+                    this.setInnerHtml(match);
+                }
+            };
+
             raceToSuccess(strictResolver)
                 .then(match => {
-                    if (match != undefined) {
-                        if (this.rawInnerHtml == undefined) {
-                            this.rawInnerHtml = htmlToUse;
-                        }
-                        this.lastResolvedLocale = locale;
-                        this.setInnerHtml(match);
-                    }
+                    processMatch(match);
                     resolve();
                 }).catch(_ => {
                     raceToSuccess(nonStrictResolver).then(match => {
-                        if (match != undefined) {
-                            if (this.rawInnerHtml == undefined) {
-                                this.rawInnerHtml = htmlToUse;
-                            }
-                            this.lastResolvedLocale = locale;
-                            this.setInnerHtml(match);
-                        }
+                        processMatch(match);
                         resolve();
-                    })
-                        .catch(e => reject(e));
+                    }).catch(e => reject(e));
                 });
         });
     }


### PR DESCRIPTION
This PR adds a possible solution for #2 . 

This solution adds an understanding of "strict" revolvers. A strict resolver resolves on the full value of `navigator.language` e.g. `en-US`. A non-strict one would resolve with `en` in this case.

If `getInnerHTML()` is called, it checks if revolvers are available and then calls `resolveI18n`. This will asynchously check the strict resolvers for any matches. If it finds a match, it will call `setInnerHtml`. If it can't find a strict match, it'll try the non strict resolvers. If they can't find a result, the function rejects. 