### PR TITLE
Path variables

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -69,11 +69,9 @@ export class Router implements IRouter {
     }
 
     private findMatchingPath(path: string): string {
-        if (this.pathVariables.length == 0 || !stringIncludesCurlyBrace(path)) {
-            // Short path
-            if (this.componentMap.has(path)) {
-                return path;
-            }
+        // Short path
+        if (this.componentMap.has(path)) {
+            return path;
         }
 
         if (path.endsWith("/")) {

--- a/src/RouterCommon.ts
+++ b/src/RouterCommon.ts
@@ -1,0 +1,31 @@
+export const splitAtSlash = (s: string): Array<string> => s.split("/");
+export const stringIncludesCurlyBrace = (s: string): boolean => s.includes("{");
+
+export const pathVariableRegex = /{([a-zA-Z$_][a-zA-Z$_0-9]+)}/;
+export function splitPathVars(path: string): Array<string> {
+    const splittedPath = splitAtSlash(path);
+
+    return splittedPath
+        .map(p => pathVariableRegex.exec(p))
+        .filter(m => m != null)
+        .map(m => m[1]);
+}
+
+export function matchSubPath(splittedKnownPath: Array<string>, splitted: Array<string>): boolean {
+    for (let i = 0; i < splittedKnownPath.length; i++) {
+        const knownSubPath = splittedKnownPath[i];
+        const givenSubPath = splitted[i];
+
+        if (givenSubPath == undefined) {
+            return false;
+        }
+
+        if (!stringIncludesCurlyBrace(knownSubPath)) {
+            if (!(knownSubPath == givenSubPath)) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}

--- a/src/vdom/Props.ts
+++ b/src/vdom/Props.ts
@@ -67,6 +67,9 @@ export class Props implements Cloneable<Props>{
 
     public getProp(key: string): PropValue {
         let value = this.props.get(key);
+        if (value == undefined) {
+            return undefined;
+        }
         if (typeof value == 'string' || typeof value == 'number') {
             return value;
         }


### PR DESCRIPTION
This PR adds understanding of path variables to the router

PoC here: https://github.com/fredlahde/eisen-path-vars

The following formal constraints apply:

- A path variable is defined by anything surrounded by curly braces, e.g.: `/foo/{id}`
- In a component one can get the value from a path variable from the props using the following syntax: `_<name>`, e.g.: `props.getProp("_id")` to get the id from above
- Valid names for path variables are defined in the same way variable identifiers in JS are: https://mathiasbynens.be/notes/javascript-identifiers

Let me know what you think